### PR TITLE
Fix: Adjust HashMap typing in BookingActivity for nullables

### DIFF
--- a/app/src/main/java/com/example/elektronicarebeta1/BookingActivity.kt
+++ b/app/src/main/java/com/example/elektronicarebeta1/BookingActivity.kt
@@ -193,7 +193,7 @@ class BookingActivity : AppCompatActivity() {
             }
             
             // Create repair request data
-            val repairData: HashMap<String, Any> = hashMapOf(
+            val repairData: HashMap<String, Any?> = hashMapOf(
                 "deviceType" to deviceType,
                 "deviceModel" to deviceModel,
                 "issueDescription" to issueDescription,
@@ -211,7 +211,7 @@ class BookingActivity : AppCompatActivity() {
             }
             
             // Submit repair request
-            val repairId = FirebaseManager.createRepairRequest(repairData as Map<String, Any>)
+            val repairId = FirebaseManager.createRepairRequest(repairData as Map<String, Any?>)
             
             if (repairId != null) {
                 runOnUiThread {


### PR DESCRIPTION
Following up on previous commit to fix build errors:
- Modified `repairData` HashMap in `BookingActivity.kt` to be of type `HashMap<String, Any?>`.
- This change allows for null values for fields like Date?, Double?, and String? which were causing type mismatch errors when interacting with Firestore, which expects `Map<String, Any?>` in these cases.