### PR TITLE
Fix: Align FirebaseManager with nullable data for repair requests

### DIFF
--- a/app/src/main/java/com/example/elektronicarebeta1/firebase/FirebaseManager.kt
+++ b/app/src/main/java/com/example/elektronicarebeta1/firebase/FirebaseManager.kt
@@ -83,7 +83,7 @@ object FirebaseManager {
         }
     }
     
-    suspend fun createRepairRequest(repairData: Map<String, Any>): String? {
+    suspend fun createRepairRequest(repairData: Map<String, Any?>): String? {
         val userId = getUserId() ?: return null
         val repairWithUser = repairData.toMutableMap()
         repairWithUser.putIfAbsent("createdAt", Date()) // Default if not provided


### PR DESCRIPTION
- Modified `FirebaseManager.createRepairRequest` to accept `Map<String, Any?>` instead of `Map<String, Any>`. This change allows `BookingActivity` to send data that includes nullable fields (e.g., for dates or prices that might not be set initially) directly to Firestore, which supports nullable types.
- This resolves the type mismatch where `BookingActivity` prepared a `Map<String, Any?>` but `FirebaseManager.createRepairRequest` expected `Map<String, Any>`.