### PR TITLE
Hotfix: Correct usage of appointmentTimestamp in HistoryActivity

### DIFF
--- a/app/src/main/java/com/example/elektronicarebeta1/HistoryActivity.kt
+++ b/app/src/main/java/com/example/elektronicarebeta1/HistoryActivity.kt
@@ -102,7 +102,7 @@ class HistoryActivity : AppCompatActivity() {
         serviceTypeText.text = repair.issueDescription
         
         val dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.getDefault())
-        val dateString = repair.scheduledDate?.let { dateFormat.format(it) } ?: "Not scheduled"
+        val dateString = repair.appointmentTimestamp?.let { dateFormat.format(it) } ?: "Not scheduled"
         dateText.text = dateString
         
         locationText.text = repair.location ?: "Not specified"


### PR DESCRIPTION
This commit resolves an `Unresolved reference: scheduledDate` error in `HistoryActivity.kt`. The error occurred because the `Repair` model was updated to use `appointmentTimestamp` instead of `scheduledDate`, but `HistoryActivity.kt` was not updated accordingly in the previous commit.

The `addRepairToView` function in `HistoryActivity.kt` has been modified to use `repair.appointmentTimestamp` when accessing and formatting the repair's date for display.